### PR TITLE
Add SenML app

### DIFF
--- a/apps/senml/Makefile.senml
+++ b/apps/senml/Makefile.senml
@@ -1,0 +1,1 @@
+senml_src = senml-api.c senml-json-formatter.c senml-cbor-formatter.c

--- a/apps/senml/README.md
+++ b/apps/senml/README.md
@@ -1,0 +1,126 @@
+# senml app
+The senml app is an API for creating SenML messages in JSON or CBOR format.  
+It handles the formatting of the SenML pack conforming to [RFC 8428](https://tools.ietf.org/html/rfc8428). It can also be used to create SenSML messages.
+
+## Project code needs
+
+```c
+#include "senml-json.h"
+```  
+and/or  
+```c
+#include "senml-cbor.h"
+```  
+depending on desired format
+
+## Build
+
+To include in project:
+in Makefile add
+
+```
+APPS += senml
+```
+
+You also need to link in a library for printing floating point numbers, such as `libprintf_flt` for AVR if you are using the JSON format.
+
+## Use
+
+API is used through different macros:  
+`SENML_INIT_JSON` or `SENML_INIT_CBOR`,  
+`SENML_START_PACK`,  
+`SENML_ADD_RECORD`,  
+and `SENML_END_PACK`.  
+
+The SenML message is written into the buffer given as an argument.
+`SENML_ADD_RECORD` also takes field name-value pairs as arguments. The supported fields are:
+
+| Field name    | Data type |
+| ------------- |:---------:|
+| BASE_NAME     | char *    |
+| BASE_TIME     | float     |
+| BASE_UNIT     | char *    |
+| BASE_VALUE    | float     |
+| BASE_SUM      | float     |
+| BASE_VERSION  | int       |
+| NAME          | char *    |
+| UNIT          | char *    |
+| VALUE         | float     |
+| STRING_VALUE  | char *    |
+| BOOLEAN_VALUE | int(*)    |
+| DATA_VALUE    | char *    |
+| SUM           | float     |
+| TIME          | float     |
+| UPDATE_TIME   | float     |
+
+(*) 0 = false, all other values = true
+
+Maximum int value and string length is 65535 in CBOR formatter (can be extended if needed).
+
+Note: When using JSON format, floating point numbers are printed using `%g` format with a precision of 6 digits. This can result in rounding errors.
+
+### Macros
+```c
+// Initializes SenML API to use JSON format
+void SENML_INIT_JSON()
+```
+```c
+// Initializes SenML API to use CBOR format
+void SENML_INIT_CBOR()
+```
+```c
+// Begins a new SenML message in the given buffer and returns the number of characters written.
+int SENML_START_PACK(buf_ptr, buf_len)
+```
+```c
+// Adds a record with the given fields in the given buffer and returns the number of characters written.
+// For example 
+// ADD_RECORD(buf_ptr, buf_len, BASE_NAME, "name", BASE_UNIT, "unit", VALUE, 4.6)
+// adds a record with the fields bn = name, bu = unit, v = 4.6
+int SENML_ADD_RECORD(buf_ptr, buf_len, ...)
+```
+```c
+// Ends the SenML message in the given buffer and returns the number of characters written.
+// Shall not be called in the beginning of a buffer if using JSON since it needs to step backwards in the buffer and overwrite the last record separation character.
+int SENML_END_PACK(buf_ptr, buf_len)
+```
+
+## Example usage
+```c
+#define BUFFER_SIZE 1024
+
+static char buffer[BUFFER_SIZE];
+char* buf_ptr = buffer;
+int len = 0;
+
+SENML_INIT_JSON();
+len += SENML_START_PACK(buf_ptr + len, BUFFER_SIZE - len);
+len += SENML_ADD_RECORD(buf_ptr + len, BUFFER_SIZE - len, BASE_NAME, "urn:dev:ow:10e2073a01080063", NAME, "voltage", UNIT, "V", VALUE, 120.1);
+len += SENML_ADD_RECORD(buf_ptr + len, BUFFER_SIZE - len, NAME, "current", UNIT, "A", VALUE, 1.2);
+len += SENML_END_PACK(buf_ptr + len, BUFFER_SIZE - len);
+
+printf("%s", buffer);
+```
+Should print
+```json
+[{"bn":"urn:dev:ow:10e2073a01080063:","n":"voltage","u":"V","v":120.1},{"n":"current","u":"A","v":1.2}]
+```
+## Code structure
+The different lables are defined in `label.h`.  
+The main code that handles the different labels is in `senml-api.c`.  
+Formatting is handled in `senml-cbor-fomatter.c` and `senml-json-formatter.c`, both implementing the functions defined in `senml-formatter.h`  
+User macros defined in `senml-json.h` and `senml-cbor.h` provide a formatter to the main functions in `senml-api.c`.  
+
+## Future work
+Implementation of XML and EXI.  
+Add support for double- and half-precision floating point numbers.  
+
+## Authors
+Erik Flink   \
+Isak Olsson \
+Nelly Friman \
+Anton Bothin   \
+Andreas Sjödin \
+Jacob Klasmark  \
+Carina Wickström \
+Valter Lundegårdh 

--- a/apps/senml/label.h
+++ b/apps/senml/label.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef LABEL_H_
+#define LABEL_H_
+typedef enum {
+	BASE_NAME,
+	BASE_TIME,
+	BASE_UNIT,
+	BASE_VALUE,
+	BASE_SUM,
+	BASE_VERSION,
+	NAME,
+	UNIT,
+	VALUE,
+	STRING_VALUE,
+	BOOLEAN_VALUE,
+	DATA_VALUE,
+	SUM,
+	TIME,
+	UPDATE_TIME,
+	END
+} Label;
+#endif

--- a/apps/senml/senml-api.c
+++ b/apps/senml/senml-api.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdarg.h>
+#include <stdio.h>
+#include "label.h"
+#include "senml-formatter.h"
+
+struct senml_formatter formatter;
+
+void
+senml_init(struct senml_formatter frmttr)
+{
+  formatter = frmttr;
+}
+int
+senml_start_pack(char *buf_ptr, int buf_len)
+{
+  return formatter.start_pack(buf_ptr, buf_len);
+}
+int
+senml_end_pack(char *buf_ptr, int buf_len)
+{
+  return formatter.end_pack(buf_ptr, buf_len);
+}
+int
+senml_add_record(char *buf_ptr, int buf_len, Label label, ...)
+{
+  int len = 0;
+  va_list args;
+  va_start(args, label);
+  len += formatter.start_record(buf_ptr, buf_len);
+  while(label != END) {
+    switch(label) {
+    case BASE_NAME:
+    case BASE_UNIT:
+    case UNIT:
+    case NAME:
+    case STRING_VALUE:
+    case DATA_VALUE:
+    {
+      char *str = va_arg(args, char *);
+      len += formatter.append_str_field(&buf_ptr[len], buf_len - len, label, str);
+      break;
+    }
+    case BASE_TIME:
+    case BASE_VALUE:
+    case BASE_SUM:
+    case VALUE:
+    case SUM:
+    case TIME:
+    case UPDATE_TIME:
+    {
+      float dbl = va_arg(args, double);
+      len += formatter.append_float_field(&buf_ptr[len], buf_len - len, label, dbl);
+      break;
+    }
+    case BOOLEAN_VALUE:
+    {
+      int b = va_arg(args, int);
+      len += formatter.append_bool_field(&buf_ptr[len], buf_len - len, label, b);
+      break;
+    }
+    case BASE_VERSION:
+    {
+      int i = va_arg(args, int);
+      len += formatter.append_int_field(&buf_ptr[len], buf_len - len, label, i);
+      break;
+    }
+    default:
+      break;
+    }
+
+    label = va_arg(args, Label);
+  }
+  len += formatter.end_record(&buf_ptr[len], buf_len - len);
+  return len;
+}

--- a/apps/senml/senml-api.h
+++ b/apps/senml/senml-api.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SENML_API_H_
+#define SENML_API_H_
+#include "label.h"
+#include "senml-formatter.h"
+
+#define SENML_START_PACK(buf_ptr, buf_len) senml_start_pack(buf_ptr, buf_len)
+#define SENML_END_PACK(buf_ptr, buf_len) senml_end_pack(buf_ptr, buf_len)
+
+#define SENML_ADD_RECORD(buf_ptr, buf_len, ...) senml_add_record(buf_ptr, buf_len, __VA_ARGS__, END)
+
+void senml_init(struct senml_formatter frmttr);
+int senml_end_pack(char *buf_ptr, int buf_len);
+int senml_start_pack(char *buf_ptr, int buf_len);
+int senml_add_record(char *buf_ptr, int buf_len, Label label, ...);
+#endif

--- a/apps/senml/senml-cbor-formatter.c
+++ b/apps/senml/senml-cbor-formatter.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include "label.h"
+#include "senml-formatter.h"
+
+/* translated SenML labels to CBOR labels according to RFC8428 page 19 */
+static const unsigned char label_cbor[] = {
+  0x21,
+  0x22,
+  0x23,
+  0x24,
+  0x25,
+  0x20,
+  0x00,
+  0x01,
+  0x02,
+  0x03,
+  0x04,
+  0x08,
+  0x05,
+  0x06,
+  0x07
+};
+/* 0x9F stands for start of indefinite length array */
+int
+start_pack_cbor(char *buffer, int buffer_len)
+{
+  return snprintf(buffer, buffer_len, "%c", 0x9F);
+}
+/* 0xFF stands for "break" indefinite length array */
+int
+end_pack_cbor(char *buffer, int buffer_len)
+{
+  return snprintf(buffer, buffer_len, "%c", 0xFF);
+}
+/* 0xBF stands for start indefinite length map */
+int
+start_record_cbor(char *buffer, int buffer_len)
+{
+  return snprintf(buffer, buffer_len, "%c", 0xBF);
+}
+/* 0xFF stands for "break" indefinite length map */
+int
+end_record_cbor(char *buffer, int buffer_len)
+{
+  return snprintf(buffer, buffer_len, "%c", 0xFF);
+}
+/* max int value or length of string is 65535. Can be extended if needed. */
+static int
+data_type_cbor_convert(char *buffer, int buffer_len, unsigned char type, int value)
+{
+  if(value < 24) {
+    return snprintf(buffer, buffer_len, "%c", type | (unsigned char)value);
+  } else if(value < 256) {
+    return snprintf(buffer, buffer_len, "%c%c", type | 0x18, (unsigned char)value);
+  } else if(value < 65536) {
+    return snprintf(buffer, buffer_len, "%c%c%c", type | 0x19, (uint8_t)(value >> 8) & 0xFF, (uint8_t)value & 0xFF);
+  }
+  return 0;
+}
+int
+append_str_field_cbor(char *buffer, int buffer_len, Label label, char *value)
+{
+  uint8_t len = 0;
+
+  len += snprintf(&buffer[len], buffer_len - len, "%c", label_cbor[label]);
+
+  int number_of_chars = 0;
+  while(*value != '\0') {
+    number_of_chars++;
+    value++;
+  }
+  /* 0x60 for text */
+  len += data_type_cbor_convert(&buffer[len], buffer_len - len, 0x60, number_of_chars);
+
+  value = value - number_of_chars;
+  len += snprintf(&buffer[len], buffer_len - len, "%s", value);
+
+  return len;
+}
+int
+append_int_field_cbor(char *buffer, int buffer_len, Label label, int value)
+{
+  uint8_t len = 0;
+
+  len += snprintf(&buffer[len], buffer_len - len, "%c", label_cbor[label]);
+  /* 0x00 for positive/unsigned int */
+  len += data_type_cbor_convert(&buffer[len], buffer_len - len, 0x00, value);
+
+  return len;
+}
+int
+append_dbl_field_cbor(char *buffer, int buffer_len, Label label, float value)
+{
+  uint8_t len = 0;
+
+  /* 0xFA for start of float value */
+  len += snprintf(&buffer[len], buffer_len - len, "%c%c", label_cbor[label], 0xFA);
+
+  union {
+    float f_val;
+    uint32_t u_val;
+  } u32;
+
+  u32.f_val = value;
+
+  int i;
+  for(i = 0; i < 4; i++) {
+    len += snprintf(&buffer[len], buffer_len - len, "%c", (uint8_t)((u32.u_val >> 8 * (3 - i)) & 0xFF));
+  }
+  return len;
+}
+int
+append_bool_field_cbor(char *buffer, int buffer_len, Label label, int value)
+{
+  if(value == 0) {
+    return snprintf(buffer, buffer_len, "%c%c", label_cbor[label], 0xF4);
+  } else {
+    return snprintf(buffer, buffer_len, "%c%c", label_cbor[label], 0xF5);
+  }
+}
+const struct senml_formatter senml_cbor_formatter = {
+  start_record_cbor,
+  end_record_cbor,
+  start_pack_cbor,
+  end_pack_cbor,
+  append_str_field_cbor,
+  append_dbl_field_cbor,
+  append_bool_field_cbor,
+  append_int_field_cbor
+};

--- a/apps/senml/senml-cbor-formatter.h
+++ b/apps/senml/senml-cbor-formatter.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SENML_CBOR_FORMATTER_H_
+#define SENML_CBOR_FORMATTER_H_
+#include "label.h"
+#include "senml-formatter.h"
+
+extern const struct senml_formatter senml_cbor_formatter;
+#endif

--- a/apps/senml/senml-cbor.h
+++ b/apps/senml/senml-cbor.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SENML_CBOR_H_
+#define SENML_CBOR_H_
+#include "senml-cbor-formatter.h"
+#include "senml-api.h"
+#define SENML_INIT_CBOR() senml_init(senml_cbor_formatter)
+#endif

--- a/apps/senml/senml-formatter.h
+++ b/apps/senml/senml-formatter.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SENML_OUTPUT_H_
+#define SENML_OUTPUT_H_
+#include "label.h"
+
+struct senml_formatter {
+  int (*start_record)(char *buf_ptr, int remaining);
+  int (*end_record)(char *buf_ptr, int remaining);
+  int (*start_pack)(char *buf_ptr, int remaining);
+  int (*end_pack)(char *buf_ptr, int remaining);
+  int (*append_str_field)(char *buf_ptr, int remaining, Label label, char *str);
+  int (*append_float_field)(char *buf_ptr, int remaining, Label label, float flt);
+  int (*append_bool_field)(char *buf_ptr, int remaining, Label label, int b);
+  int (*append_int_field)(char *buf_ptr, int remaining, Label label, int i);
+};
+#endif

--- a/apps/senml/senml-json-formatter.c
+++ b/apps/senml/senml-json-formatter.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "label.h"
+#include <stdio.h>
+#include "senml-formatter.h"
+
+static const char *label_strings[] = {
+  "bn",
+  "bt",
+  "bu",
+  "bv",
+  "bs",
+  "bver",
+  "n",
+  "u",
+  "v",
+  "vs",
+  "vb",
+  "vd",
+  "s",
+  "t",
+  "ut"
+};
+
+int
+start_pack_json(char *buf_ptr, int remaining)
+{
+  return snprintf(buf_ptr, remaining, "[");
+}
+int
+end_pack_json(char *buf_ptr, int remaining)
+{
+  buf_ptr -= sizeof(char);
+
+  if(buf_ptr[0] == ',') {
+    return snprintf(buf_ptr, remaining, "]") - 1;
+  } else {
+    buf_ptr += sizeof(char);
+    return snprintf(buf_ptr, remaining, "]");
+  }
+}
+int
+start_record_json(char *buf_ptr, int remaining)
+{
+  return snprintf(buf_ptr, remaining, "{");
+}
+int
+end_record_json(char *buf_ptr, int remaining)
+{
+  buf_ptr -= sizeof(char);
+  return snprintf(buf_ptr, remaining, "},") - 1;
+}
+int
+append_str_field_json(char *buf_ptr, int remaining, Label label, char *str)
+{
+  return snprintf(buf_ptr, remaining, "\"%s\":\"%s\",", label_strings[label], str);
+}
+int
+append_dbl_field_json(char *buf_ptr, int remaining, Label label, float flt)
+{
+  return snprintf(buf_ptr, remaining, "\"%s\":%g,", label_strings[label], flt);
+}
+int
+append_bool_field_json(char *buf_ptr, int remaining, Label label, int b)
+{
+  if(b) {
+
+    return snprintf(buf_ptr, remaining, "\"%s\":true,", label_strings[label]);
+  } else {
+    return snprintf(buf_ptr, remaining, "\"%s\":false,", label_strings[label]);
+  }
+}
+int
+append_int_field_json(char *buf_ptr, int remaining, Label label, int i)
+{
+  return snprintf(buf_ptr, remaining, "\"%s\":%d,", label_strings[label], i);
+}
+const struct senml_formatter senml_json_formatter = {
+  start_record_json,
+  end_record_json,
+  start_pack_json,
+  end_pack_json,
+  append_str_field_json,
+  append_dbl_field_json,
+  append_bool_field_json,
+  append_int_field_json
+};

--- a/apps/senml/senml-json-formatter.h
+++ b/apps/senml/senml-json-formatter.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SENML_JSON_FORMATTER_H_
+#define SENML_JSON_FORMATTER_H_
+#include "label.h"
+#include "senml-formatter.h"
+
+extern const struct senml_formatter senml_json_formatter;
+#endif

--- a/apps/senml/senml-json.h
+++ b/apps/senml/senml-json.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SENML_JSON_H_
+#define SENML_JSON_H_
+#include "senml-json-formatter.h"
+#include "senml-api.h"
+#define SENML_INIT_JSON() senml_init(senml_json_formatter)
+#endif

--- a/apps/senml/unit-testing/Makefile
+++ b/apps/senml/unit-testing/Makefile
@@ -1,0 +1,8 @@
+CONTIKI_PROJECT = unit-testing
+all: $(CONTIKI_PROJECT)
+
+APPS+=senml
+APPS+=unit-test
+
+CONTIKI = ../../../
+include $(CONTIKI)/Makefile.include

--- a/apps/senml/unit-testing/README.md
+++ b/apps/senml/unit-testing/README.md
@@ -1,0 +1,39 @@
+# Unit testing for SenML API
+Unit tests for the SenML API using the unit-test app.
+## How to run
+Create the build using make. Native will be used by default if no target is specified.
+```
+make
+./unit-testing.native
+```
+## Use
+### Registering new tests
+In unit-testing.c, register new tests by adding
+```UNIT_TEST_REGISTER(name, "description")```
+in the start of the file.
+
+Run the test by adding ```UNIT_TEST_RUN(name);``` in the ```PROCESS_THREAD``` method:
+### Example test design
+```
+UNIT_TEST(name) {
+  int a, b;
+  UNIT_TEST_BEGIN();
+  a = 1;
+  b = 2;
+  UNIT_TEST_ASSERT(a+b==3);
+  UNIT_TEST_END();
+}
+```
+This test will pass since 1+2=3
+## Common errors
+**make can't find curses.h**  
+`sudo apt-get install libncurses5-dev libncursesw5-dev`
+## Authors
+Anton Bothin  
+Erik Flink  
+Nelly Friman  
+Jacob Klasmark  
+Valter Lundegårdh  
+Isak Olsson  
+Andreas Sjödin  
+Carina Wickström  

--- a/apps/senml/unit-testing/unit-testing.c
+++ b/apps/senml/unit-testing/unit-testing.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2019, 
+ * Anton Bothin,
+ * Erik Flink,
+ * Nelly Friman,
+ * Jacob Klasmark,
+ * Valter Lundegårdh, 
+ * Isak Olsson,
+ * Andreas Sjödin,
+ * Carina Wickström.
+ * All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names of the authors may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "contiki.h"
+#include "unit-test.h"
+#include "senml-json.h"
+#include "senml-cbor.h"
+#include <string.h>
+#include <stdio.h>
+
+#define BUFFER_SIZE 1024
+
+UNIT_TEST_REGISTER(json_empty_string, "JSON: Adding 0 records should return \"[]\"");
+UNIT_TEST_REGISTER(json_noise_sensor, "JSON: Noise sensor example");
+UNIT_TEST_REGISTER(json_many_parameters, "JSON: Many parameters");
+UNIT_TEST_REGISTER(json_multiple_records, "JSON: Multiple records");
+UNIT_TEST_REGISTER(cbor_empty_string, "CBOR: Adding 0 records should return \"[]\"");
+UNIT_TEST_REGISTER(cbor_noise_sensor, "CBOR: Noise sensor example");
+UNIT_TEST_REGISTER(cbor_many_parameters, "CBOR: Many parameters");
+UNIT_TEST_REGISTER(cbor_multiple_records, "CBOR: Multiple records");
+
+static int
+strcmpn(char *str1, char *str2, int n)
+{
+  int i;
+  for(i = 0; i < n; i++) {
+    if(str1[i] - str2[i] != 0) {
+      return str1[i] - str2[i];
+    }
+  }
+  return 0;
+}
+UNIT_TEST(json_empty_string){
+  char buffer_pointer[BUFFER_SIZE];
+  int len = 0;
+  UNIT_TEST_BEGIN();
+
+  SENML_INIT_JSON();
+  len += SENML_START_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  len += SENML_END_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+
+  UNIT_TEST_ASSERT(strcmp(buffer_pointer, "[]") == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST(json_noise_sensor){
+  char buffer_pointer[BUFFER_SIZE];
+  int len = 0;
+  UNIT_TEST_BEGIN();
+  SENML_INIT_JSON();
+  len += SENML_START_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  len += SENML_ADD_RECORD(buffer_pointer + len, BUFFER_SIZE - len, BASE_NAME, "urn:dev:mac:fcc23d0000003790", UNIT, "dB", BOOLEAN_VALUE, 0, VALUE, 50.00);
+  len += SENML_END_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  UNIT_TEST_ASSERT(strcmp(buffer_pointer, "[{\"bn\":\"urn:dev:mac:fcc23d0000003790\",\"u\":\"dB\",\"vb\":false,\"v\":50}]") == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST(json_many_parameters){
+  char buffer_pointer[BUFFER_SIZE];
+  int len = 0;
+  UNIT_TEST_BEGIN();
+
+  SENML_INIT_JSON();
+  len += SENML_START_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  len += SENML_ADD_RECORD(buffer_pointer + len, BUFFER_SIZE - len, BASE_NAME, "urn:dev:mac:fcc23d0000003790", BASE_TIME, 123456789.00, BASE_UNIT, "Volt", BASE_VERSION, 2, VALUE, -1.00, SUM, 0.00, TIME, 643.00, UPDATE_TIME, 0.00);
+  len += SENML_END_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  UNIT_TEST_ASSERT(strcmp(buffer_pointer, "[{\"bn\":\"urn:dev:mac:fcc23d0000003790\",\"bt\":1.23457e+08,\"bu\":\"Volt\",\"bver\":2,\"v\":-1,\"s\":0,\"t\":643,\"ut\":0}]") == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST(json_multiple_records){
+  char buffer_pointer[BUFFER_SIZE];
+  int len = 0;
+  UNIT_TEST_BEGIN();
+
+  SENML_INIT_JSON();
+  len += SENML_START_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  len += SENML_ADD_RECORD(buffer_pointer + len, BUFFER_SIZE - len, BASE_NAME, "urn:dev:mac:fcc23d0000003790", UNIT, "dB", VALUE, 50.00);
+  len += SENML_ADD_RECORD(buffer_pointer + len, BUFFER_SIZE - len, BASE_NAME, "urn:dev:mac:fcc23d0000003788", UNIT, "w", VALUE, 0.00);
+  len += SENML_ADD_RECORD(buffer_pointer + len, BUFFER_SIZE - len, BASE_NAME, "urn:dev:mac:fcc23d0000013290", UNIT, "m", VALUE, 35.25);
+  len += SENML_END_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+
+  UNIT_TEST_ASSERT(strcmp(buffer_pointer, "[{\"bn\":\"urn:dev:mac:fcc23d0000003790\",\"u\":\"dB\",\"v\":50},{\"bn\":\"urn:dev:mac:fcc23d0000003788\",\"u\":\"w\",\"v\":0},{\"bn\":\"urn:dev:mac:fcc23d0000013290\",\"u\":\"m\",\"v\":35.25}]") == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST(cbor_empty_string){
+  char buffer_pointer[BUFFER_SIZE];
+  int len = 0;
+  UNIT_TEST_BEGIN();
+
+  SENML_INIT_CBOR();
+  len += SENML_START_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  len += SENML_END_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+
+  char str[] = { 0x9F, 0xFF, 0x00 };
+
+  UNIT_TEST_ASSERT(strcmpn(buffer_pointer, str, sizeof(str) / sizeof(char)) == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST(cbor_noise_sensor){
+  char buffer_pointer[BUFFER_SIZE];
+  int len = 0;
+  UNIT_TEST_BEGIN();
+
+  SENML_INIT_CBOR();
+  len += SENML_START_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  len += SENML_ADD_RECORD(buffer_pointer + len, BUFFER_SIZE - len, BASE_NAME, "urn:mac:fcc2948375028573", UNIT, "dB", VALUE, 59.23);
+  len += SENML_END_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  char str[] = { 0x9F, 0xBF, 0x21, 0x78, 0x18, 0x75, 0x72, 0x6E, 0x3A, 0x6D, 0x61, 0x63, 0x3A, 0x66, 0x63, 0x63, 0x32, 0x39, 0x34, 0x38, 0x33, 0x37, 0x35, 0x30, 0x32, 0x38, 0x35, 0x37, 0x33, 0x01, 0x62, 0x64, 0x42, 0x02, 0xFA, 0x42, 0x6C, 0xEB, 0x85, 0xFF, 0xFF, 0x00 };
+  UNIT_TEST_ASSERT(strcmpn(buffer_pointer, str, sizeof(str) / sizeof(char)) == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST(cbor_multiple_records){
+  char buffer_pointer[BUFFER_SIZE];
+  int len = 0;
+  UNIT_TEST_BEGIN();
+
+  SENML_INIT_CBOR();
+  len += SENML_START_PACK(buffer_pointer, BUFFER_SIZE - len);
+  len += SENML_ADD_RECORD(buffer_pointer + len, BUFFER_SIZE - len, BASE_NAME, "urn:mac:fcc2948375028573", UNIT, "dB", VALUE, 8923.223);
+  len += SENML_ADD_RECORD(buffer_pointer + len, BUFFER_SIZE - len, BOOLEAN_VALUE, 0, BASE_TIME, 123456789.00);
+  len += SENML_END_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  char str[] = { 0x9F, 0xBF, 0x21, 0x78, 0x18, 0x75, 0x72, 0x6E, 0x3A, 0x6D, 0x61, 0x63, 0x3A, 0x66, 0x63, 0x63, 0x32, 0x39, 0x34, 0x38, 0x33, 0x37, 0x35, 0x30, 0x32, 0x38, 0x35, 0x37, 0x33, 0x01, 0x62, 0x64, 0x42, 0x02, 0xFA, 0x46, 0x0B, 0x6C, 0xE4, 0xFF, 0xBF, 0x04, 0xF4, 0x22, 0xFA, 0x4C, 0xEB, 0x79, 0xA3, 0xFF, 0xFF, 0x00 };
+
+  UNIT_TEST_ASSERT(strcmpn(buffer_pointer, str, sizeof(str) / sizeof(char)) == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST(cbor_many_parameters) {
+  char buffer_pointer[BUFFER_SIZE];
+  int len = 0;
+  UNIT_TEST_BEGIN();
+
+  SENML_INIT_CBOR();
+  len += SENML_START_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+  len += SENML_ADD_RECORD(buffer_pointer + len, BUFFER_SIZE - len, BASE_VERSION, 5, UNIT, "m/s", VALUE, 12.608765);
+  len += SENML_END_PACK(buffer_pointer + len, BUFFER_SIZE - len);
+
+  char str[] = { 0x9F, 0xBF, 0x20, 0x05, 0x01, 0x63, 0x6D, 0x2F, 0x73, 0x02, 0xFA, 0x41, 0x49, 0xBD, 0x80, 0xFF, 0xFF, 0x00 };
+  UNIT_TEST_ASSERT(strcmpn(buffer_pointer, str, sizeof(str) / sizeof(char)) == 0);
+
+  UNIT_TEST_END();
+}
+
+PROCESS(unit_testing, "Unit Testing");
+
+AUTOSTART_PROCESSES(&unit_testing);
+
+PROCESS_THREAD(unit_testing, ev, data){
+  PROCESS_BEGIN();
+
+  UNIT_TEST_RUN(json_empty_string);
+  UNIT_TEST_RUN(json_noise_sensor);
+  UNIT_TEST_RUN(json_many_parameters);
+  UNIT_TEST_RUN(json_multiple_records);
+  UNIT_TEST_RUN(cbor_empty_string);
+  UNIT_TEST_RUN(cbor_noise_sensor);
+  UNIT_TEST_RUN(cbor_many_parameters);
+  UNIT_TEST_RUN(cbor_multiple_records);
+
+  PROCESS_END();
+}


### PR DESCRIPTION
The senml app is an API for creating SenML messages in JSON or CBOR format.  
It handles the formatting of the SenML pack conforming to [RFC 8428](https://tools.ietf.org/html/rfc8428). It can also be used to create SenSML messages.

Co-authored-by: Anton Bothin <abothin@kth.se>
Co-authored-by: Nelly Friman <nellyf@kth.se>
Co-authored-by: Jacob Klasmark <jacobkl@kth.se>
Co-authored-by: Valter Lundegårdh <valterlu@kth.se>
Co-authored-by: Isak Olsson <isakol@kth.se>
Co-authored-by: Andreas Sjödin <ansjod@kth.se>
Co-authored-by: Carina Wickström <carinawi@kth.se>